### PR TITLE
chore(deps): update anatole to v1.20.0 and Hugo to 0.164.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://blog.koh-sh.com"
 title = "koh's blog"
 hasCJKLanguage = true
 summaryLength = 80
-languageCode = "ja"
+locale = "ja"
 defaultContentLanguage = "ja"
 enableRobotsTXT = true
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/koh-sh/blog
 
 go 1.23.3
 
-require github.com/lxndrblz/anatole v1.19.0 // indirect
+require github.com/lxndrblz/anatole v1.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/lxndrblz/anatole v1.19.0 h1:ywF3To/pOnljEgy/Gk9TanLxURUd7zS2qxpIqDe2dt0=
 github.com/lxndrblz/anatole v1.19.0/go.mod h1:hy61SRyUDKaWw2P+cERt9UPde5guWyVKgtjdzRF5bfI=
+github.com/lxndrblz/anatole v1.20.0 h1:PZs5p0TsMvPa09S+V+hBd+PQJPCVAIpVX/EyD1G4msM=
+github.com/lxndrblz/anatole v1.20.0/go.mod h1:hy61SRyUDKaWw2P+cERt9UPde5guWyVKgtjdzRF5bfI=

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,101 @@
+{{ define "main" }}
+  <div
+    class="post {{ with .Site.Params.doNotLoadAnimations }}
+      .
+    {{ else }}
+      animated fadeInDown
+    {{ end }}"
+  >
+    <div class="post__content">
+      {{ .Content }}
+    </div>
+
+    <!-- (Optional) Home
+          -- on top of `mainSections` content (aka posts) ;
+          -- as declared in content/_index.md
+
+          One can set `mainSections = [""]` and have the content/_index.md specified here
+      -->
+  </div>
+
+  {{ if .Params.mainSectionsTitle }}
+    <div
+      class="post {{ with .Site.Params.doNotLoadAnimations }}
+        .
+      {{ else }}
+        animated fadeInDown
+      {{ end }}"
+    >
+      <div class="post__content">
+        <h2>{{ .Params.mainSectionsTitle }}</h2>
+      </div>
+    </div>
+  {{ end }}
+
+  {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
+  {{ range $paginator.Pages }}
+    <div
+      class="post {{ with .Site.Params.doNotLoadAnimations }}
+        .
+      {{ else }}
+        animated fadeInDown
+      {{ end }}"
+    >
+      {{ if .Params.thumbnail }}
+        <div class="post__thumbnail-wrapper">
+          <a href="{{ .RelPermalink }}">
+            <img class="post__thumbnail" src="{{ .Params.thumbnail | relURL }}" alt="Thumbnail image" loading="lazy" />
+          </a>
+        </div>
+      {{ end }}
+      <div class="post__content">
+        {{ if (eq .Site.Params.disableTitleCapitalization true) }}
+          <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+        {{ else }}
+          <h3><a href="{{ .RelPermalink }}">{{ upper .Title }}</a></h3>
+        {{ end }}
+        {{ if .Site.Params.fullPostContent }}
+          <p>{{ .Content | safeHTML | plainify }}</p>
+        {{ else }}
+          <p>{{ .Summary | safeHTML | plainify }}</p>
+        {{ end }}
+        <!-- add read more -->
+        {{- if and (.Truncated) (.Site.Params.readMore) -}}
+          <a href="{{ .RelPermalink }}">{{ i18n "read_more" }}</a>
+        {{- end -}}
+      </div>
+
+      <!--  -->
+      <div class="post__footer">
+        <em class="fas fa-calendar-day"></em>
+        <span class="post__footer-date"
+          >{{ if isset .Site.Params "indexdateformat" }}
+            {{ if .Site.Params.localizedDates }}
+              {{ time.Format .Site.Params.indexDateFormat .Date }}
+            {{ else }}
+              {{ .Date.Format .Site.Params.indexDateFormat }}
+            {{ end }}
+
+          {{ else }}
+            {{ if .Site.Params.localizedDates }}
+              {{ time.Format "Mon, Jan 2, 2006" .Date }}
+            {{ else }}
+              {{ .Date.Format "Mon, Jan 2, 2006" }}
+            {{ end }}
+
+          {{ end }}</span
+        >
+        {{ with .Page.Params.Categories }}
+          {{ partial "taxonomy/categories.html" . }}
+        {{ end }}
+
+        {{ with .Page.Params.Tags }}
+          {{ partial "taxonomy/tags.html" . }}
+        {{ end }}
+      </div>
+    </div>
+  {{ end }}
+  <div class="pagination">
+    {{ partial "pagination.html" . }}
+  </div>
+{{ end }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-hugo-extended = "0.157.0"
+hugo-extended = "0.164.0"
 node = "24.5.0"
 
 [tasks.server]


### PR DESCRIPTION
## Summary

- Update anatole theme from v1.19.0 to v1.20.0
- Update Hugo Extended from 0.157.0 to 0.164.0 (mise.toml)
- Rename deprecated `languageCode` config key to `locale` in `config.toml`
- Override `layouts/index.html` to keep plain-text post summaries on the home page

## Background

anatole v1.20.0 references `.Site.Language.Direction` in its templates, a field introduced in Hugo 0.158.0. Updating only the theme while staying on Hugo 0.157.0 breaks rendering of all pages with `can't evaluate field Direction in type *langs.Language`, so Hugo is updated to the latest stable 0.164.0.

The `languageCode` key was deprecated in Hugo 0.158.0; renaming it to `locale` clears the build warning.

anatole v1.20.0 also removed the `plainify` filter from `index.html`, which made post summaries on the home page render as HTML including images. A local template override restores the previous plain-text summaries.

## Verification

- `mise run build` succeeds with no warnings
- Generated HTML correctly outputs `lang="ja"` / `dir="ltr"`
- Home page summaries are plain text with no `<img>` tags, same as before the upgrade
- `mise run ci` (lint / type-check / test) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5oe3P2321LaTtj8HKzcHZ